### PR TITLE
k8s-deploy: Fix variable name

### DIFF
--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -24,7 +24,7 @@ do
   SECRET_FILE=${SECRET_FILES[$index]}
   echo "Appending ${CI_SHA1} to secret filename"
   cp ${SECRET_FILE} ${SECRET_FILE}-${CI_SHA1}
-  SECRET_FIL=${SECRET_FILE}-${CI_SHA1}
+  SECRET_FILE=${SECRET_FILE}-${CI_SHA1}
   echo "Applying ${SECRET_FILE}"
   kubectl apply -f ${SECRET_FILE}
   if [ $? -ne 0 ]


### PR DESCRIPTION
This variable is otherwise unused. Correct it with `E` to match the 
pattern for `CONFIGMAP_FILE` above this.
